### PR TITLE
Optimize source generator to use Godot's MethodName for better performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-- Replace with coming additions, changes, removals, or fixes
+### Changed
+
+- Source generator now uses `MethodName` (Godot's generated StringName constants) instead of string literals or `nameof()` for better performance
+  - Eliminates string-to-StringName conversion overhead on every command registration
+  - Provides consistent type-safe method references for all methods (regardless of parameter count)
+  - Resolves issue #13
 
 ## [0.0.1-beta-008] - 2025-05-31
 

--- a/Limbo.Console.Generator/ConsoleCommandGenerator.cs
+++ b/Limbo.Console.Generator/ConsoleCommandGenerator.cs
@@ -146,9 +146,7 @@ namespace Limbo.Console.Sharp.Generator
 
             foreach (var method in methods)
             {
-                var callable = method.Method.Parameters.Length == 0
-                    ? $"new Callable(this, nameof({method.Method.Name}))"
-                    : $"new Callable(this, \"{method.Method.Name}\")"; // TODO: consider arg-aware logic
+                var callable = $"new Callable(this, MethodName.{method.Method.Name})";
 
                 var registerCall = method.Description != null
                     ? $"LimboConsole.RegisterCommand({callable}, \"{method.Name}\", \"{method.Description}\");"


### PR DESCRIPTION
Replace string literals and nameof() with MethodName in the generated
Callable constructors. This leverages Godot's generated StringName
constants, eliminating string-to-StringName conversion overhead on
every command registration.

Changes:
- Use MethodName.{MethodName} for all methods (both parameterless and
  methods with parameters)
- Remove unnecessary parameter count check
- Remove TODO comment that suggested considering arg-aware logic
- Update CHANGELOG.md with performance improvement details

Benefits:
- No string-to-StringName conversion cost at runtime
- Consistent type-safe method references across all methods
- Follows Godot's recommended pattern (as shown in Demo.cs)
- Better performance for command registration

Fixes #13