### PR TITLE
Add support for inline string arrays in AutoComplete attribute

### DIFF
--- a/Limbo.Console.Abstractions/AutoCompleteAttribute.cs
+++ b/Limbo.Console.Abstractions/AutoCompleteAttribute.cs
@@ -3,27 +3,49 @@
 namespace Limbo.Console.Sharp
 {
     /// <summary>
-    /// Defines an autocomplete source for a ConsoleCommand parameter 
+    /// Defines an autocomplete source for a ConsoleCommand parameter
     /// </summary>
     /// <remarks>
     /// Placed on the ConsoleCommand function
     /// </remarks>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Parameter, AllowMultiple = true)]
     public sealed class AutoCompleteAttribute : Attribute {
-        
+
         /// <summary>
         /// The name of the method providing the autocomplete suggestions
         /// </summary>
         public string MethodName { get; }
-        
+
+        /// <summary>
+        /// Inline array of autocomplete values
+        /// </summary>
+        public string[] InlineValues { get; }
+
         /// <summary>
         /// The index of the parameter in the AutoComplete function's signature.
         /// </summary>
         public int ArgumentIndex { get; }
-        
+
+        /// <summary>
+        /// Creates an autocomplete attribute with a method name
+        /// </summary>
+        /// <param name="methodName">The name of the method that returns autocomplete suggestions</param>
+        /// <param name="argumentIndex">The parameter index (0-based)</param>
         public AutoCompleteAttribute(string methodName, int argumentIndex = 0)
         {
-            (MethodName, ArgumentIndex) = (methodName, argumentIndex);
+            MethodName = methodName;
+            ArgumentIndex = argumentIndex;
+        }
+
+        /// <summary>
+        /// Creates an autocomplete attribute with inline values
+        /// </summary>
+        /// <param name="inlineValues">Array of string values for autocomplete</param>
+        /// <param name="argumentIndex">The parameter index (0-based)</param>
+        public AutoCompleteAttribute(string[] inlineValues, int argumentIndex = 0)
+        {
+            InlineValues = inlineValues;
+            ArgumentIndex = argumentIndex;
         }
     }
 }

--- a/Limbo.Console.Generator/AutoCompletion/AutoCompleteDefinition.cs
+++ b/Limbo.Console.Generator/AutoCompletion/AutoCompleteDefinition.cs
@@ -9,10 +9,25 @@ namespace Limbo.Console.Generator.AutoCompletion
             SourceMethod = sourceMethod;
             ArgIndex = argIndex;
             Location = location;
+            InlineValues = null;
+        }
+
+        public AutoCompleteDefinition(string[] inlineValues, int argIndex, Location location)
+        {
+            InlineValues = inlineValues;
+            ArgIndex = argIndex;
+            Location = location;
+            SourceMethod = null;
         }
 
         public readonly string SourceMethod;
+        public readonly string[] InlineValues;
         public readonly int ArgIndex;
         public readonly Location Location;
+
+        /// <summary>
+        /// Returns true if this definition uses inline values, false if it uses a method name
+        /// </summary>
+        public bool IsInline => InlineValues != null;
     }
 }

--- a/Limbo.Console.Generator/AutoCompletion/AutoCompletes.cs
+++ b/Limbo.Console.Generator/AutoCompletion/AutoCompletes.cs
@@ -66,11 +66,26 @@ namespace Limbo.Console.Generator.AutoCompletion
         {
             // Add warning for auto complete attributes that are on a parameter but not on a ConsoleCommand method
             // Add warning for auto complete attributes that are on a parameter and use the index value (it will be ignored)
-            var sourceMethod = attr.ConstructorArguments[0].Value as string ?? string.Empty;
+            var firstArg = attr.ConstructorArguments[0];
             var argIndex = attr.ConstructorArguments.Length > 1 ? (int)(attr.ConstructorArguments[1].Value ?? 0) : 0;
             if (index != null)
                 argIndex = index.Value;
-            return new AutoCompleteDefinition(sourceMethod, argIndex, attr.ApplicationSyntaxReference?.GetSyntax()?.GetLocation());
+
+            var location = attr.ApplicationSyntaxReference?.GetSyntax()?.GetLocation();
+
+            // Check if the first argument is a string (method name) or an array (inline values)
+            if (firstArg.Kind == TypedConstantKind.Array)
+            {
+                // Inline array values
+                var values = firstArg.Values.Select(v => v.Value?.ToString() ?? string.Empty).ToArray();
+                return new AutoCompleteDefinition(values, argIndex, location);
+            }
+            else
+            {
+                // Method name
+                var sourceMethod = firstArg.Value as string ?? string.Empty;
+                return new AutoCompleteDefinition(sourceMethod, argIndex, location);
+            }
         }
     }
 }

--- a/Limbo.Console.Generator/ConsoleCommandGenerator.cs
+++ b/Limbo.Console.Generator/ConsoleCommandGenerator.cs
@@ -157,7 +157,7 @@ namespace Limbo.Console.Sharp.Generator
                     {
                         var fieldName = $"__AutoComplete_{method.Method.Name}_{autoComplete.ArgIndex}_{fieldCounter++}";
                         var values = string.Join(", ", autoComplete.InlineValues.Select(v => $"\"{EscapeString(v)}\""));
-                        sb.AppendLine($"  private static readonly string[] {fieldName} = new string[] {{ {values} }};");
+                        sb.AppendLine($"  private static readonly StringName[] {fieldName} = new StringName[] {{ {values} }};");
                     }
                 }
             }

--- a/Limbo.Console.Generator/ConsoleCommandGenerator.cs
+++ b/Limbo.Console.Generator/ConsoleCommandGenerator.cs
@@ -106,6 +106,7 @@ namespace Limbo.Console.Sharp.Generator
 
 
             sb.AppendLine($"{accessibility} partial class {classSymbol.Name} {{");
+            AddInlineAutoCompleteFields(sb, methods);
             AddRegisterConsoleCommands(sb, methods);
             sb.AppendLine();
             AddUnregisterConsoleCommands(sb, methods);
@@ -145,10 +146,30 @@ namespace Limbo.Console.Sharp.Generator
             return value.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
         }
 
+        private static void AddInlineAutoCompleteFields(StringBuilder sb, IEnumerable<CommandMethodInfo> methods)
+        {
+            var fieldCounter = 0;
+            foreach (var method in methods)
+            {
+                foreach (var autoComplete in method.AutoCompletes)
+                {
+                    if (autoComplete.IsInline)
+                    {
+                        var fieldName = $"__AutoComplete_{method.Method.Name}_{autoComplete.ArgIndex}_{fieldCounter++}";
+                        var values = string.Join(", ", autoComplete.InlineValues.Select(v => $"\"{EscapeString(v)}\""));
+                        sb.AppendLine($"  private static readonly string[] {fieldName} = new string[] {{ {values} }};");
+                    }
+                }
+            }
+            if (fieldCounter > 0)
+                sb.AppendLine();
+        }
+
         private static void AddRegisterConsoleCommands(StringBuilder sb, IEnumerable<CommandMethodInfo> methods)
         {
             sb.AppendLine(" private void RegisterConsoleCommands() {");
 
+            var fieldCounter = 0;
             foreach (var method in methods)
             {
                 var callable = method.Method.Parameters.Length == 0
@@ -165,9 +186,9 @@ namespace Limbo.Console.Sharp.Generator
                 {
                     if (autoComplete.IsInline)
                     {
-                        // Generate code for inline array values
-                        var values = string.Join(", ", autoComplete.InlineValues.Select(v => $"\"{EscapeString(v)}\""));
-                        sb.AppendLine($"    LimboConsole.AddArgumentAutocompleteSource(\"{method.Name}\", {autoComplete.ArgIndex}, Callable.From(() => new string[] {{ {values} }}));");
+                        // Reference the static readonly field
+                        var fieldName = $"__AutoComplete_{method.Method.Name}_{autoComplete.ArgIndex}_{fieldCounter++}";
+                        sb.AppendLine($"    LimboConsole.AddArgumentAutocompleteSource(\"{method.Name}\", {autoComplete.ArgIndex}, Callable.From(() => {fieldName}));");
                     }
                     else
                     {

--- a/Limbo.Console.Generator/ConsoleCommandGenerator.cs
+++ b/Limbo.Console.Generator/ConsoleCommandGenerator.cs
@@ -140,6 +140,11 @@ namespace Limbo.Console.Sharp.Generator
             }
         }
 
+        private static string EscapeString(string value)
+        {
+            return value.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+        }
+
         private static void AddRegisterConsoleCommands(StringBuilder sb, IEnumerable<CommandMethodInfo> methods)
         {
             sb.AppendLine(" private void RegisterConsoleCommands() {");
@@ -158,7 +163,17 @@ namespace Limbo.Console.Sharp.Generator
 
                 foreach (var autoComplete in method.AutoCompletes)
                 {
-                    sb.AppendLine($"    LimboConsole.AddArgumentAutocompleteSource(\"{method.Name}\", {autoComplete.ArgIndex}, Callable.From(() => {autoComplete.SourceMethod}()));");
+                    if (autoComplete.IsInline)
+                    {
+                        // Generate code for inline array values
+                        var values = string.Join(", ", autoComplete.InlineValues.Select(v => $"\"{EscapeString(v)}\""));
+                        sb.AppendLine($"    LimboConsole.AddArgumentAutocompleteSource(\"{method.Name}\", {autoComplete.ArgIndex}, Callable.From(() => new string[] {{ {values} }}));");
+                    }
+                    else
+                    {
+                        // Generate code for method name (existing behavior)
+                        sb.AppendLine($"    LimboConsole.AddArgumentAutocompleteSource(\"{method.Name}\", {autoComplete.ArgIndex}, Callable.From(() => {autoComplete.SourceMethod}()));");
+                    }
                 }
             }
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ You can also use the `[AutoComplete]` attribute to quickly define autocompletes 
 
 > 💡You _must_ call `RegisterConsoleCommands()` to enable your class's [AutoComplete]'s!
 
+**Method-based autocomplete:**
 
 ```csharp
 [ConsoleCommand]
@@ -132,6 +133,38 @@ private string[] Colors() {
 ```
 
 This example adds an auto-complete source for the first argument of the `FavoriteColorCommand` command, suggesting the values `red`, `blue`, and `green`.
+
+**Inline array autocomplete:**
+
+You can also define autocomplete values inline without needing a separate method:
+
+```csharp
+[ConsoleCommand]
+[AutoComplete(new string[] { "red", "white", "orange", "green" })]
+public void ColorCommand(string color) {
+  // Do something
+}
+```
+
+For multi-parameter commands, specify the argument index (note: parameter indices are 0-based):
+
+```csharp
+[ConsoleCommand]
+[AutoComplete(new string[] { "apple", "banana", "cherry", "date" }, 1)]
+public void FruitCommand(int quantity, string fruit) {
+  // Do something with quantity and fruit
+}
+```
+
+In newer C# versions, you can use collection expressions:
+
+```csharp
+[ConsoleCommand]
+[AutoComplete(["red", "white", "orange", "green"])]
+public void ColorCommand(string color) {
+  // Do something
+}
+```
 
 ### More examples
 

--- a/demo/Demo.cs
+++ b/demo/Demo.cs
@@ -50,14 +50,14 @@ public partial class Demo : Node2D
     }
 
     [ConsoleCommand(description: "A command with inline autocomplete values!")]
-    [AutoComplete(new string[] { "red", "white", "orange", "green" })]
+    [AutoComplete(new string[] {"red", "white", "orange", "green"})]     
     public void InlineAutoCompleteCommand(string color)
     {
         LimboConsole.Info("InlineAutoCompleteCommand executed with color: " + color);
     }
 
     [ConsoleCommand(description: "Multi-arg command with inline autocomplete on second parameter")]
-    [AutoComplete(new string[] { "apple", "banana", "cherry", "date" }, 1)]
+    [AutoComplete(["apple", "banana", "cherry", "date" ], 1)] // In C# 12 and later you can use array literals
     public void FruitCommand(int quantity, string fruit)
     {
         LimboConsole.Info($"FruitCommand executed with quantity: {quantity}, fruit: {fruit}");

--- a/demo/Demo.cs
+++ b/demo/Demo.cs
@@ -49,6 +49,20 @@ public partial class Demo : Node2D
         LimboConsole.Info("AttributeCommandWithArg executed with arg: " + arg1);
     }
 
+    [ConsoleCommand(description: "A command with inline autocomplete values!")]
+    [AutoComplete(new string[] { "red", "white", "orange", "green" })]
+    public void InlineAutoCompleteCommand(string color)
+    {
+        LimboConsole.Info("InlineAutoCompleteCommand executed with color: " + color);
+    }
+
+    [ConsoleCommand(description: "Multi-arg command with inline autocomplete on second parameter")]
+    [AutoComplete(new string[] { "apple", "banana", "cherry", "date" }, 1)]
+    public void FruitCommand(int quantity, string fruit)
+    {
+        LimboConsole.Info($"FruitCommand executed with quantity: {quantity}, fruit: {fruit}");
+    }
+
 #pragma warning disable LIMBO1002 // Invalid AutoComplete Attribute Usage
     /// <summary>
     /// An example of a command ignoring an error but the source generator will still generate code that compiles


### PR DESCRIPTION
Implements issue #8 - adds the ability to define autocomplete values
directly in the attribute without needing a separate method.

Changes:
- Added new constructor to AutoCompleteAttribute accepting string[]
- Modified AutoCompleteDefinition to support both method names and inline values
- Updated parser in AutoCompletes.cs to detect and handle array arguments
- Enhanced code generator to emit appropriate code for inline arrays
- Added string escaping for safe code generation
- Updated README.md with comprehensive examples
- Added demo examples showcasing inline autocomplete usage

Usage examples:
  [AutoComplete(new string[] { "red", "white", "orange", "green" })]
  [AutoComplete(["apple", "banana", "cherry"], 1)]  // C# 12+ syntax

The feature maintains full backward compatibility with existing
method-based autocomplete usage.